### PR TITLE
fix: Make model badge job name compatible with gitlab

### DIFF
--- a/.github/workflows/model-badge.yml
+++ b/.github/workflows/model-badge.yml
@@ -1,7 +1,7 @@
 # Copyright DB Netz AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
-name: generate model badge
+name: generate-model-badge
 
 on: push
 


### PR DESCRIPTION
In order to have the same interface in the collab manager for gitlab and github we need both jobs to have matching names